### PR TITLE
Fix: Calculate timestamp of incident 

### DIFF
--- a/common/src/main/java/com/simra/konsumgandalf/common/constants/AppDates.java
+++ b/common/src/main/java/com/simra/konsumgandalf/common/constants/AppDates.java
@@ -1,0 +1,15 @@
+package com.simra.konsumgandalf.common.constants;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+public final class AppDates {
+
+	public static final Date START_OF_RECORDING = Date
+		.from(LocalDate.parse("2018-01-01").atStartOfDay().atZone(ZoneId.systemDefault()).toInstant());
+
+	public static final Date FALLBACK_DATE = Date
+		.from(LocalDate.parse("2017-12-31").atStartOfDay().atZone(ZoneId.systemDefault()).toInstant());
+
+}

--- a/common/src/main/java/com/simra/konsumgandalf/common/constants/CronExpressions.java
+++ b/common/src/main/java/com/simra/konsumgandalf/common/constants/CronExpressions.java
@@ -3,7 +3,7 @@ package com.simra.konsumgandalf.common.constants;
 /**
  * Defines reusable cron expressions.
  */
-public class CronExpressions {
+public final class CronExpressions {
 
 	public static final String EVERY_DAY = "0 0 0 * * ?";
 

--- a/common/src/main/java/com/simra/konsumgandalf/common/constants/DangerousColors.java
+++ b/common/src/main/java/com/simra/konsumgandalf/common/constants/DangerousColors.java
@@ -1,6 +1,6 @@
 package com.simra.konsumgandalf.common.constants;
 
-public class DangerousColors {
+public final class DangerousColors {
 
 	public static final String RED_500 = "#EF4444";
 

--- a/common/src/main/java/com/simra/konsumgandalf/common/utils/services/FileReaderService.java
+++ b/common/src/main/java/com/simra/konsumgandalf/common/utils/services/FileReaderService.java
@@ -1,16 +1,12 @@
 package com.simra.konsumgandalf.common.utils.services;
 
 import org.springframework.stereotype.Service;
-
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.ObjectOutputStream;
 import java.net.URL;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Date;
 
 @Service
 public class FileReaderService {
@@ -32,6 +28,15 @@ public class FileReaderService {
 			}
 		}
 		catch (Exception e) {
+			throw new RuntimeException("Error reading file", e);
+		}
+	}
+
+	public Date getFileLastModified(String path) {
+		try {
+			return new Date(Files.getLastModifiedTime(Paths.get(path)).toMillis());
+		}
+		catch (IOException e) {
 			throw new RuntimeException("Error reading file", e);
 		}
 	}

--- a/common/src/test/java/com/simra/konsumgandalf/common/utils/services/FileReaderServiceTest.java
+++ b/common/src/test/java/com/simra/konsumgandalf/common/utils/services/FileReaderServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Date;
 
 @ExtendWith(MockitoExtension.class)
 public class FileReaderServiceTest {
@@ -40,6 +41,29 @@ public class FileReaderServiceTest {
 		public void testReadFileFromPath_FileNotFound() {
 			assertThrows(RuntimeException.class, () -> {
 				fileReaderService.readFileFromPath("nonexistentfile.txt");
+			});
+		}
+
+	}
+
+	@Nested
+	class testGetFileLastModified {
+
+		@Test
+		public void testGetFileLastModified_ValidFile() throws Exception {
+			Path tempFile = tempDir.resolve("testfile.txt");
+			String content = "Hello, World!";
+			Files.write(tempFile, content.getBytes());
+
+			Date result = fileReaderService.getFileLastModified(tempFile.toString());
+
+			assertEquals(Files.getLastModifiedTime(tempFile).toMillis(), result.getTime());
+		}
+
+		@Test
+		public void testGetFileLastModified_FileNotFound() {
+			assertThrows(RuntimeException.class, () -> {
+				fileReaderService.getFileLastModified("nonexistentfile.txt");
 			});
 		}
 

--- a/documentation/uml/CalculateIncidentTimestamp.puml
+++ b/documentation/uml/CalculateIncidentTimestamp.puml
@@ -1,0 +1,23 @@
+@startuml
+start
+
+if (is incident timestamp non corrupted?) then (yes)
+    stop
+else (no)
+endif
+
+if (matching incident's lat/lng found) then (yes)
+    stop
+endif
+
+if (file has modified timestamp?) then (yes)
+    stop
+endif
+
+if (Ride timestamps there?) then (yes)
+    stop
+endif
+
+:Use FALLBACK_DATE;
+stop
+@enduml

--- a/rides/src/main/java/com/simra/konsumgandalf/rides/services/RideEntityService.java
+++ b/rides/src/main/java/com/simra/konsumgandalf/rides/services/RideEntityService.java
@@ -2,20 +2,19 @@ package com.simra.konsumgandalf.rides.services;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.simra.konsumgandalf.common.models.classes.Coordinate;
 import com.simra.konsumgandalf.common.models.classes.OsmrMatchInformation;
+import com.simra.konsumgandalf.common.models.classes.RideLocation;
 import com.simra.konsumgandalf.common.models.entities.PlanetOsmLine;
 import com.simra.konsumgandalf.common.models.entities.RideEntity;
 import com.simra.konsumgandalf.common.models.entities.RideIncident;
-import com.simra.konsumgandalf.common.models.classes.RideLocation;
 import com.simra.konsumgandalf.common.models.enums.IncidentType;
+import com.simra.konsumgandalf.common.models.maps.IxFunctionToParticipantTypeMap;
+import com.simra.konsumgandalf.common.repositories.PlanetOsmLineRepository;
 import com.simra.konsumgandalf.common.utils.services.BloomFilterService;
 import com.simra.konsumgandalf.common.utils.services.CsvUtilService;
 import com.simra.konsumgandalf.common.utils.services.FileReaderService;
-import com.simra.konsumgandalf.common.models.maps.IxFunctionToParticipantTypeMap;
-import com.simra.konsumgandalf.common.repositories.PlanetOsmLineRepository;
-import com.simra.konsumgandalf.valhalla.services.ValhallaTraceAttributesService;
 import com.simra.konsumgandalf.rides.repositories.RideEntityRepository;
+import com.simra.konsumgandalf.valhalla.services.ValhallaTraceAttributesService;
 import jakarta.transaction.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +26,8 @@ import org.springframework.stereotype.Service;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -36,6 +37,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+
+import static com.simra.konsumgandalf.common.constants.AppDates.FALLBACK_DATE;
+import static com.simra.konsumgandalf.common.constants.AppDates.START_OF_RECORDING;
 
 @Service
 @Transactional
@@ -163,21 +167,9 @@ public class RideEntityService {
 					}
 				});
 
-				Date incidentDate = new Date(incident.getTs());
-				// If the incident date is before 1st January 2018, we can assume that the
-				// date is not correct
-				if (incidentDate.before(new Date(1514761200))) {
-					incident.setTimeStamp(incidentDate);
-				}
-				else {
-					rideLocationList.stream()
-						.filter(location -> location.getLng() == incident.getLng()
-								&& location.getLat() == incident.getLat())
-						.findFirst()
-						.ifPresentOrElse(location -> {
-							incident.setTimeStamp(new Date(location.getTimeStamp()));
-						}, () -> incident.setTimeStamp(new Date((rideTimestamps[0] + rideTimestamps[1]) / 2)));
-				}
+				Date dateOfIncident = getTimeStampFromRideIncident(incident, rideLocationList, rideTimestamps,
+						rideEntity.getPath());
+				incident.setTimeStamp(dateOfIncident);
 
 				return incident;
 			})
@@ -277,6 +269,52 @@ public class RideEntityService {
 		}
 	}
 
+	/**
+	 * This method tries to find the timestamp of a ride incident with multiple
+	 * strategies.
+	 * @param incident - The ride incident
+	 * @param rideLocationList - The list of ride locations of the same ride as the
+	 * incident
+	 * @param rideTimestamps - The start and end timestamps of the ride
+	 * @param ridePath - The path to the ride file
+	 * @return - The timestamp of the ride incident
+	 */
+	protected Date getTimeStampFromRideIncident(RideIncident incident, List<RideLocation> rideLocationList,
+			long[] rideTimestamps, String ridePath) {
+		Date incidentDate = new Date(incident.getTs());
+		if (isAfterStartOfRecording(incidentDate)) {
+			return incidentDate;
+		}
+
+		Optional<Date> matchedDate = rideLocationList.stream()
+			.filter(location -> location.getLng() == incident.getLng() && location.getLat() == incident.getLat())
+			.findFirst()
+			.map(location -> new Date(location.getTimeStamp()));
+
+		if (matchedDate.isPresent() && isAfterStartOfRecording(matchedDate.get())) {
+			return matchedDate.get();
+		}
+
+		if (rideTimestamps.length == 2) {
+			incidentDate = new Date((rideTimestamps[0] + rideTimestamps[1]) / 2);
+		}
+
+		if (!isAfterStartOfRecording(incidentDate)) {
+			try {
+				incidentDate = fileReaderService.getFileLastModified(ridePath);
+			}
+			catch (Exception e) {
+				_logger.error("Error getting last modified date of file", e);
+			}
+		}
+
+		if (!isAfterStartOfRecording(incidentDate)) {
+			incidentDate = FALLBACK_DATE;
+		}
+
+		return incidentDate;
+	}
+
 	protected boolean validateRideLocation(RideLocation rideLocation) {
 		return rideLocation.getLat() != 0 && rideLocation.getLng() != 0 && rideLocation.getTimeStamp() != 0;
 	}
@@ -287,6 +325,10 @@ public class RideEntityService {
 
 	public Map<String, String[]> getRideGeometries(long id) {
 		return rideEntityRepository.findRideGeometries(id);
+	}
+
+	private boolean isAfterStartOfRecording(Date date) {
+		return (date != null) && date.after(START_OF_RECORDING);
 	}
 
 }

--- a/rides/src/test/java/com/simra/konsumgandalf/rides/services/RideEntityServiceTest.java
+++ b/rides/src/test/java/com/simra/konsumgandalf/rides/services/RideEntityServiceTest.java
@@ -1,5 +1,7 @@
 package com.simra.konsumgandalf.rides.services;
 
+import static com.simra.konsumgandalf.common.constants.AppDates.FALLBACK_DATE;
+import static com.simra.konsumgandalf.common.constants.AppDates.START_OF_RECORDING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -31,9 +33,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.context.TestPropertySource;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -111,7 +111,7 @@ public class RideEntityServiceTest {
 			RideIncident resultRideIncident = result.getRideIncidents().get(0);
 			assertEquals(resultRideIncident.getParticipantsInvolved(),
 					Collections.singletonList(ParticipantType.BUS_COACH));
-			assertEquals(resultRideIncident.getTimeStamp(), new Date(2000));
+			assertEquals(resultRideIncident.getTimeStamp(), FALLBACK_DATE);
 
 			assertEquals(result.getRideStart(), new Date(1000));
 			assertEquals(result.getRideEnd(), new Date(1000));
@@ -262,6 +262,89 @@ public class RideEntityServiceTest {
 			String result = rideEntityService.generateCoordinateString(rideLocationList);
 
 			assertEquals(expectedString, result);
+		}
+
+	}
+
+	@Nested
+	class GetTimeStampFromRideIncident {
+
+		private RideIncident mockRideIncident;
+
+		private List<RideLocation> mockRideLocationList;
+
+		private long[] mockTimestamps;
+
+		private String mockRidePath;
+
+		private long START_OF_RECORDING_TIMESTAMP;
+
+		@BeforeEach
+		public void setUp() {
+			mockRideIncident = new RideIncident();
+			mockRideLocationList = new ArrayList<>();
+			mockTimestamps = new long[] {};
+			mockRidePath = "valid.csv";
+			START_OF_RECORDING_TIMESTAMP = START_OF_RECORDING.getTime();
+		}
+
+		Date getExpectedDate(long timestamp) {
+			return new Date(START_OF_RECORDING_TIMESTAMP + timestamp);
+		}
+
+		@Test
+		public void testGetTimeStampFromRideIncident_ValidTs() {
+			mockRideIncident.setTs(START_OF_RECORDING_TIMESTAMP + 1000);
+
+			Date result = rideEntityService.getTimeStampFromRideIncident(mockRideIncident, mockRideLocationList,
+					mockTimestamps, mockRidePath);
+
+			assertEquals(getExpectedDate(1000), result);
+		}
+
+		@Test
+		public void testGetTimeStampFromRideIncident_LocationTimeStamp() {
+			mockRideIncident.setLat(1.0);
+			mockRideIncident.setLng(2.0);
+
+			RideLocation mockRideLocation = new RideLocation();
+			mockRideLocation.setLat(1.0);
+			mockRideLocation.setLng(2.0);
+			mockRideLocation.setTimeStamp(START_OF_RECORDING_TIMESTAMP + 2000);
+			mockRideLocationList.add(mockRideLocation);
+
+			Date result = rideEntityService.getTimeStampFromRideIncident(mockRideIncident, mockRideLocationList,
+					mockTimestamps, mockRidePath);
+
+			assertEquals(getExpectedDate(2000), result);
+		}
+
+		@Test
+		public void testGetTimeStampFromRideIncident_RidePath() {
+			mockTimestamps = new long[] { START_OF_RECORDING_TIMESTAMP + 1000, START_OF_RECORDING_TIMESTAMP + 10000 };
+
+			Date result = rideEntityService.getTimeStampFromRideIncident(mockRideIncident, mockRideLocationList,
+					mockTimestamps, mockRidePath);
+
+			assertEquals(getExpectedDate(5500), result);
+		}
+
+		@Test
+		public void testGetTimeStampFromRideIncident_LastModified() {
+			when(fileReaderService.getFileLastModified(mockRidePath)).thenReturn(getExpectedDate(5000));
+
+			Date result = rideEntityService.getTimeStampFromRideIncident(mockRideIncident, mockRideLocationList,
+					mockTimestamps, mockRidePath);
+
+			assertEquals(getExpectedDate(5000), result);
+		}
+
+		@Test
+		public void testGetTimeStampFromRideIncident_Fallback() {
+			Date result = rideEntityService.getTimeStampFromRideIncident(mockRideIncident, mockRideLocationList,
+					mockTimestamps, mockRidePath);
+
+			assertEquals(FALLBACK_DATE, result);
 		}
 
 	}


### PR DESCRIPTION
Often the timestamp of incidents is corrupted to 1337. 

No we employee strategies to calculate on the base of locations or files.

![incident_timestamp](https://github.com/user-attachments/assets/fdef2c8d-6dd0-46e2-9bd4-04bf11895e02)
